### PR TITLE
Fix/rms 69/memory leak

### DIFF
--- a/RickAndMorty-iOS.xcodeproj/project.pbxproj
+++ b/RickAndMorty-iOS.xcodeproj/project.pbxproj
@@ -862,7 +862,6 @@
 				F77E4B9C29B9364600B8B5CE /* MainCoordinator.swift in Sources */,
 				F7EA932229CB8F9600F7F112 /* Character.graphql.swift in Sources */,
 				F77E4B7C29B906D400B8B5CE /* AppDelegate.swift in Sources */,
-				54AC84C029C8A5DE00680F77 /* Locations.graphql.swift in Sources */,
 				54644B7929CA8AC7007FB8B3 /* EmptyData.swift in Sources */,
 				54ECFC4429C546820049ACE3 /* SearchViewModel.swift in Sources */,
 				F7604C9B29BF7219003C2906 /* LocationsView.swift in Sources */,

--- a/RickAndMorty-iOS/Delegates/AppDelegate.swift
+++ b/RickAndMorty-iOS/Delegates/AppDelegate.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import SDWebImage
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -13,6 +14,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions
                      launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
+        SDImageCache.shared.config.shouldCacheImagesInMemory = false
         return true
     }
 

--- a/RickAndMorty-iOS/ViewModel/Characters/CharacterDetailsViewModel.swift
+++ b/RickAndMorty-iOS/ViewModel/Characters/CharacterDetailsViewModel.swift
@@ -20,12 +20,12 @@ class CharacterDetailsViewModel {
 
     func fetchData(charID: String) {
         Network.shared.apollo.fetch(
-            query: RickAndMortyAPI.GetCharacterQuery(characterId: charID)) { result in
+            query: RickAndMortyAPI.GetCharacterQuery(characterId: charID)) { [weak self] result in
 
                 switch result {
                 case .success(let response):
                     if let char = response.data?.character {
-                        self.character.send(char)
+                        self?.character.send(char)
                     }
                 case .failure(let error):
                     print(error)

--- a/RickAndMorty-iOS/ViewModel/Characters/CharactersViewModel.swift
+++ b/RickAndMorty-iOS/ViewModel/Characters/CharactersViewModel.swift
@@ -8,6 +8,11 @@
 import UIKit
 import Combine
 
+struct FilterOptions {
+    var status: String
+    var gender: String
+}
+
 class CharactersViewModel {
 
     var characters = CurrentValueSubject<[RickAndMortyAPI.CharacterBasics], Never>([])
@@ -16,16 +21,20 @@ class CharactersViewModel {
             fetchData(page: currentPage)
         }
     }
-    var currentStatus = ""
-    var currentGender = ""
+
+    var filterOptions = FilterOptions(status: "", gender: "") {
+        didSet {
+            fetchData(page: 1)
+        }
+    }
 
     func fetchData(page: Int) {
         Network.shared.apollo.fetch(
             query: RickAndMortyAPI.GetCharactersQuery(
                 page: GraphQLNullable<Int>(integerLiteral: page),
                 name: nil,
-                status: GraphQLNullable<String>(stringLiteral: self.currentStatus),
-                gender: GraphQLNullable<String>(stringLiteral: self.currentGender))) { result in
+                status: GraphQLNullable<String>(stringLiteral: filterOptions.status),
+                gender: GraphQLNullable<String>(stringLiteral: filterOptions.gender))) { result in
 
                     switch result {
                     case .success(let response):

--- a/RickAndMorty-iOS/ViewModel/Characters/CharactersViewModel.swift
+++ b/RickAndMorty-iOS/ViewModel/Characters/CharactersViewModel.swift
@@ -34,12 +34,12 @@ class CharactersViewModel {
                 page: GraphQLNullable<Int>(integerLiteral: page),
                 name: nil,
                 status: GraphQLNullable<String>(stringLiteral: filterOptions.status),
-                gender: GraphQLNullable<String>(stringLiteral: filterOptions.gender))) { result in
+                gender: GraphQLNullable<String>(stringLiteral: filterOptions.gender))) { [weak self] result in
 
                     switch result {
                     case .success(let response):
                         if let results = response.data?.characters?.results {
-                            self.mapData(page: page, characters: results)
+                            self?.mapData(page: page, characters: results)
                         }
                     case .failure(let error):
                         print(error)

--- a/RickAndMorty-iOS/ViewModel/Episodes/EpisodeDetailsViewModel.swift
+++ b/RickAndMorty-iOS/ViewModel/Episodes/EpisodeDetailsViewModel.swift
@@ -19,12 +19,12 @@ class EpisodeDetailsViewModel {
 
     func fetchData(epiID: String) {
         Network.shared.apollo.fetch(
-            query: RickAndMortyAPI.GetEpisodeQuery(episodeId: epiID)) { result in
+            query: RickAndMortyAPI.GetEpisodeQuery(episodeId: epiID)) { [weak self] result in
 
                 switch result {
                 case .success(let response):
                     if let epi = response.data?.episode {
-                        self.episode.send(epi)
+                        self?.episode.send(epi)
                     }
                 case .failure(let error):
                     print(error)

--- a/RickAndMorty-iOS/ViewModel/Episodes/EpisodesViewModel.swift
+++ b/RickAndMorty-iOS/ViewModel/Episodes/EpisodesViewModel.swift
@@ -22,11 +22,11 @@ class EpisodesViewModel {
             query: RickAndMortyAPI.GetEpisodesQuery(
                 page: GraphQLNullable<Int>(integerLiteral: page),
                 name: nil,
-                episode: nil)) { result in
+                episode: nil)) { [weak self] result in
                     switch result {
                     case .success(let response):
                         if let results = response.data?.episodes?.results {
-                            self.mapData(page: page, episodes: results)
+                            self?.mapData(page: page, episodes: results)
                         }
                     case .failure(let error):
                         print(error)

--- a/RickAndMorty-iOS/ViewModel/Locations/LocationDetailsViewModel.swift
+++ b/RickAndMorty-iOS/ViewModel/Locations/LocationDetailsViewModel.swift
@@ -22,11 +22,11 @@ class LocationDetailsViewModel {
         Network.shared.apollo.fetch(
             query: RickAndMortyAPI.GetLocationQuery(
                 locationId: locationId
-                )) { result in
+                )) { [weak self] result in
                     switch result {
                     case .success(let response):
                         if let loc = response.data?.location {
-                            self.location.send(loc)
+                            self?.location.send(loc)
                         }
                     case .failure(let error):
                         print(error)

--- a/RickAndMorty-iOS/ViewModel/Locations/LocationsViewModel.swift
+++ b/RickAndMorty-iOS/ViewModel/Locations/LocationsViewModel.swift
@@ -22,11 +22,11 @@ class LocationsViewModel {
             query: RickAndMortyAPI.GetLocationsQuery(
                 page: GraphQLNullable<Int>(integerLiteral: page),
                 name: nil,
-                type: nil)) { result in
+                type: nil)) { [weak self] result in
                     switch result {
                     case .success(let response):
                         if let results = response.data?.locations?.results {
-                            self.mapData(page: page, locations: results)
+                            self?.mapData(page: page, locations: results)
                         }
                     case .failure(let error):
                         print(error)

--- a/RickAndMorty-iOS/ViewModel/Search/SearchViewModel.swift
+++ b/RickAndMorty-iOS/ViewModel/Search/SearchViewModel.swift
@@ -25,14 +25,14 @@ class SearchViewModel {
 
     func fetchData(input: String) {
         Network.shared.apollo.fetch(
-            query: RickAndMortyAPI.SearchForQuery(keyword: GraphQLNullable<String>(stringLiteral: input))) { result in
+            query: RickAndMortyAPI.SearchForQuery(keyword: GraphQLNullable<String>(stringLiteral: input))) { [weak self] result in
                 switch result {
                 case .success(let response):
-                    self.searchResults.send(response.data!)
+                    self?.searchResults.send(response.data!)
 
-                    self.characters.value = (response.data?.characters?.results?.compactMap { $0 })!
-                    self.locatonsWithGivenName.value = (response.data?.locationsWithName?.results?.compactMap { $0 })!
-                    self.locationsWithGivenType.value = (response.data?.locationsWithType?.results?.compactMap { $0 })!
+                    self?.characters.value = (response.data?.characters?.results?.compactMap { $0 })!
+                    self?.locatonsWithGivenName.value = (response.data?.locationsWithName?.results?.compactMap { $0 })!
+                    self?.locationsWithGivenType.value = (response.data?.locationsWithType?.results?.compactMap { $0 })!
 
                 case .failure(let error):
                     print(error)

--- a/RickAndMorty-iOS/Views/Characters/CharacterDetailsView.swift
+++ b/RickAndMorty-iOS/Views/Characters/CharacterDetailsView.swift
@@ -29,7 +29,7 @@ class CharacterDetailsView: UIView {
 
     private func setupConstraints() {
         collectionView.snp.makeConstraints { make in
-            make.edges.equalTo(self.safeAreaLayoutGuide).inset(UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 10))
+            make.edges.equalTo(safeAreaLayoutGuide).inset(UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 10))
         }
     }
 
@@ -69,7 +69,7 @@ class CharacterDetailsView: UIView {
             let isIndexValid =  episode.characters.indices.contains(index)
             if isIndexValid {
                 let urlString = episode.characters[index]?.image ?? ""
-                cell.characterAvatarImageViews[index].sd_setImage(with: URL(string: urlString))
+                cell.characterAvatarImageViews[index].sd_setImage(with: URL(string: urlString), placeholderImage: nil, context: [.imageThumbnailPixelSize: CGSize(width: 50, height: 50)])
             }
         }
     }
@@ -78,7 +78,7 @@ class CharacterDetailsView: UIView {
 // MARK: - CollectionView Layout
 extension CharacterDetailsView {
     private func createLayout() -> UICollectionViewLayout {
-        let layout = UICollectionViewCompositionalLayout { (sectionIndex, _) -> NSCollectionLayoutSection? in
+        let layout = UICollectionViewCompositionalLayout { [weak self] (sectionIndex, _) -> NSCollectionLayoutSection? in
 
             guard let sectionType = Section(rawValue: sectionIndex) else {
                 return nil
@@ -110,7 +110,7 @@ extension CharacterDetailsView {
 
             let headerSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .estimated(50))
             let header = NSCollectionLayoutBoundarySupplementaryItem(layoutSize: headerSize, elementKind: UICollectionView.elementKindSectionHeader, alignment: .top)
-            if self.collectionView.numberOfItems(inSection: sectionIndex) > 0 {
+            if (self?.collectionView.numberOfItems(inSection: sectionIndex) ?? 0) > 0 {
                 section.boundarySupplementaryItems = [header]
             }
             return section
@@ -125,7 +125,7 @@ extension CharacterDetailsView {
 
         if let imageUrl = image {
             let imageView = UIImageView()
-            imageView.sd_setImage(with: URL(string: imageUrl))
+            imageView.sd_setImage(with: URL(string: imageUrl), placeholderImage: nil, context: [.imageThumbnailPixelSize: CGSize(width: 50, height: 50)])
             imageView.layer.cornerRadius = 12
             imageView.clipsToBounds = true
             titleWithImage.addSubview(imageView)

--- a/RickAndMorty-iOS/Views/Characters/CharacterDetailsViewController.swift
+++ b/RickAndMorty-iOS/Views/Characters/CharacterDetailsViewController.swift
@@ -43,12 +43,6 @@ class CharacterDetailsViewController: UIViewController {
         updateTitleView()
     }
 
-    override func viewDidDisappear(_ animated: Bool) {
-            super.viewDidDisappear(true)
-            self.removeFromParent()
-            self.dismiss(animated: true, completion: nil)
-    }
-
     func showEmptyData() {
         snapshot.deleteAllItems()
         snapshot.appendSections([.appearance, .info, .location, .episodes, .empty, .emptyInfo, .emptyLocation])

--- a/RickAndMorty-iOS/Views/Characters/CharacterDetailsViewController.swift
+++ b/RickAndMorty-iOS/Views/Characters/CharacterDetailsViewController.swift
@@ -43,6 +43,12 @@ class CharacterDetailsViewController: UIViewController {
         updateTitleView()
     }
 
+    override func viewDidDisappear(_ animated: Bool) {
+            super.viewDidDisappear(true)
+            self.removeFromParent()
+            self.dismiss(animated: true, completion: nil)
+    }
+
     func showEmptyData() {
         snapshot.deleteAllItems()
         snapshot.appendSections([.appearance, .info, .location, .episodes, .empty, .emptyInfo, .emptyLocation])
@@ -53,16 +59,18 @@ class CharacterDetailsViewController: UIViewController {
     }
 
     func subscribeToViewModel() {
-        viewModel.character.sink(receiveValue: { [self] characterInfo in
-            self.title = characterInfo.name
+        viewModel.character.sink(receiveValue: { [weak self] characterInfo in
+            self?.title = characterInfo.name
             if !characterInfo.episode.isEmpty {
-                snapshot.deleteAllItems()
-                snapshot.appendSections([.appearance, .info, .location, .episodes])
-                snapshot.appendItems([CharacterDetails(characterInfo)], toSection: .appearance)
-                snapshot.appendItems([CharacterDetails(characterInfo), CharacterDetails(characterInfo), CharacterDetails(characterInfo)], toSection: .info)
-                snapshot.appendItems([CharacterDetails(characterInfo), CharacterDetails(characterInfo)], toSection: .location)
-                snapshot.appendItems(characterInfo.episode, toSection: .episodes)
-                self.dataSource.apply(snapshot, animatingDifferences: true)
+                if var snapshot = self?.snapshot {
+                    snapshot.deleteAllItems()
+                    snapshot.appendSections([.appearance, .info, .location, .episodes])
+                    snapshot.appendItems([CharacterDetails(characterInfo)], toSection: .appearance)
+                    snapshot.appendItems([CharacterDetails(characterInfo), CharacterDetails(characterInfo), CharacterDetails(characterInfo)], toSection: .info)
+                    snapshot.appendItems([CharacterDetails(characterInfo), CharacterDetails(characterInfo)], toSection: .location)
+                    snapshot.appendItems(characterInfo.episode, toSection: .episodes)
+                    self?.dataSource.apply(snapshot, animatingDifferences: true)
+                }
             }
         }).store(in: &cancellables)
     }
@@ -72,7 +80,7 @@ class CharacterDetailsViewController: UIViewController {
 extension CharacterDetailsViewController {
     // swiftlint:disable cyclomatic_complexity
     private func configureDataSource() {
-        dataSource = DataSource(collectionView: characterDetailsView.collectionView, cellProvider: { (collectionView, indexPath, characterInfo) -> UICollectionViewCell? in
+        dataSource = DataSource(collectionView: characterDetailsView.collectionView, cellProvider: { [weak self] (collectionView, indexPath, characterInfo) -> UICollectionViewCell? in
 
             let avatarCell = collectionView.dequeueReusableCell(withReuseIdentifier: AvatarCell.identifier, for: indexPath) as? AvatarCell
             let infoCell = collectionView.dequeueReusableCell(withReuseIdentifier: InfoCell.identifier, for: indexPath) as? InfoCell
@@ -82,8 +90,8 @@ extension CharacterDetailsViewController {
                 hideLoadingAnimation(currentCell: avatarCell!)
                 if let character = characterInfo as? CharacterDetails {
                     guard let image = character.item.image else { fatalError("Image not found") }
-                    self.avatarImageUrl = image
-                    avatarCell?.characterImage.sd_setImage(with: URL(string: image))
+                    self?.avatarImageUrl = image
+                    avatarCell?.characterImage.sd_setImage(with: URL(string: image), placeholderImage: nil, context: [.imageThumbnailPixelSize: CGSize(width: 300, height: 300)])
                     return avatarCell!
                 }
             case 1:
@@ -127,7 +135,7 @@ extension CharacterDetailsViewController {
             case 3:
                 if let episode = characterInfo as?
                     RickAndMortyAPI.GetCharacterQuery.Data.Character.Episode {
-                    return collectionView.dequeueConfiguredReusableCell(using: self.characterDetailsView.episodeCell,
+                    return collectionView.dequeueConfiguredReusableCell(using: (self?.characterDetailsView.episodeCell)!,
                                                                         for: indexPath,
                                                                         item: episode)
                 }
@@ -148,8 +156,8 @@ extension CharacterDetailsViewController {
         })
 
         // for custom header
-        dataSource.supplementaryViewProvider = { (_ collectionView, _ kind, indexPath) in
-            guard let headerView = self.characterDetailsView.collectionView.dequeueReusableSupplementaryView(ofKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: "HeaderView", for: indexPath) as? HeaderView else {
+        dataSource.supplementaryViewProvider = { [weak self] (_ collectionView, _ kind, indexPath) in
+            guard let headerView = self?.characterDetailsView.collectionView.dequeueReusableSupplementaryView(ofKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: "HeaderView", for: indexPath) as? HeaderView else {
                 fatalError()
             }
             var headerTitle: String

--- a/RickAndMorty-iOS/Views/Characters/CharactersFilterView.swift
+++ b/RickAndMorty-iOS/Views/Characters/CharactersFilterView.swift
@@ -76,17 +76,6 @@ class CharactersFilterView: UIView {
         return segmentControl
     }()
 
-    let applyButton: UIButton = {
-        let button = UIButton()
-        button.setTitle("Apply", for: .normal)
-        button.titleLabel?.font = UIFont(name: "Chalkboard SE Regular", size: 22)
-        button.setTitleColor(.systemBackground, for: .normal)
-        button.setTitleColor(.systemGray, for: .highlighted)
-        button.backgroundColor = .label
-        button.layer.cornerRadius = 8
-        return button
-    }()
-
     required init?(coder: NSCoder) {
         super.init(coder: coder)
     }

--- a/RickAndMorty-iOS/Views/Characters/CharactersFilterViewController.swift
+++ b/RickAndMorty-iOS/Views/Characters/CharactersFilterViewController.swift
@@ -26,7 +26,9 @@ class CharactersFilterViewController: UIViewController {
 
     init(viewModel: CharactersViewModel) {
         self.viewModel = viewModel
-        self.currentFilterOptions = CurrentValueSubject<FilterOptions, Never>(FilterOptions(status: viewModel.filterOptions.status, gender: viewModel.filterOptions.gender))
+        self.currentFilterOptions = CurrentValueSubject<FilterOptions, Never>(FilterOptions(
+                                                                              status: viewModel.filterOptions.status,
+                                                                              gender: viewModel.filterOptions.gender))
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -37,24 +39,33 @@ class CharactersFilterViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        addTargets()
+        bindToViewModel()
+        restoreStatesFromViewModel()
+    }
+
+    private func addTargets() {
         charactersFilterView.statusSegmentControl.addTarget(self, action: #selector(statusValueChanged), for: .valueChanged)
         charactersFilterView.genderSegmentControl.addTarget(self, action: #selector(genderValueChanged), for: .valueChanged)
         charactersFilterView.dismissButton.addTarget(self, action: #selector(dismissButtonTapped), for: .touchUpInside)
         charactersFilterView.clearButton.addTarget(self, action: #selector(clearButtonTapped), for: .touchUpInside)
+    }
 
-        if let currentStatusIndex = statuses.firstIndex(of: viewModel.filterOptions.status) {
-            charactersFilterView.statusSegmentControl.selectedSegmentIndex = currentStatusIndex
-        }
-
-        if let currentGenderIndex = genders.firstIndex(of: viewModel.filterOptions.gender) {
-            charactersFilterView.genderSegmentControl.selectedSegmentIndex = currentGenderIndex
-        }
-
+    private func bindToViewModel() {
         currentFilterOptions
             .receive(on: DispatchQueue.main)
             .map({ $0 })
             .assign(to: \.filterOptions, on: self.viewModel)
             .store(in: &cancellables)
+    }
+
+    private func restoreStatesFromViewModel() {
+        if let currentStatusIndex = statuses.firstIndex(of: viewModel.filterOptions.status) {
+            charactersFilterView.statusSegmentControl.selectedSegmentIndex = currentStatusIndex
+        }
+        if let currentGenderIndex = genders.firstIndex(of: viewModel.filterOptions.gender) {
+            charactersFilterView.genderSegmentControl.selectedSegmentIndex = currentGenderIndex
+        }
     }
 
     @objc private func statusValueChanged() {

--- a/RickAndMorty-iOS/Views/Characters/CharactersFilterViewController.swift
+++ b/RickAndMorty-iOS/Views/Characters/CharactersFilterViewController.swift
@@ -16,12 +16,17 @@ class CharactersFilterViewController: UIViewController {
     private let charactersFilterView = CharactersFilterView()
     private var viewModel: CharactersViewModel
 
+    private var currentFilterOptions: CurrentValueSubject<FilterOptions, Never>
+
+    private var cancellables = Set<AnyCancellable>()
+
     required init?(coder: NSCoder) {
         fatalError("This class does not support NSCoder")
     }
 
     init(viewModel: CharactersViewModel) {
         self.viewModel = viewModel
+        self.currentFilterOptions = CurrentValueSubject<FilterOptions, Never>(FilterOptions(status: viewModel.filterOptions.status, gender: viewModel.filterOptions.gender))
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -39,28 +44,32 @@ class CharactersFilterViewController: UIViewController {
         charactersFilterView.dismissButton.addTarget(self, action: #selector(dismissButtonTapped), for: .touchUpInside)
         charactersFilterView.clearButton.addTarget(self, action: #selector(clearButtonTapped), for: .touchUpInside)
 
-        if let currentStatusIndex = statuses.firstIndex(of: viewModel.currentStatus) {
+        if let currentStatusIndex = statuses.firstIndex(of: viewModel.filterOptions.status) {
             charactersFilterView.statusSegmentControl.selectedSegmentIndex = currentStatusIndex
         }
 
-        if let currentGenderIndex = genders.firstIndex(of: viewModel.currentGender) {
+        if let currentGenderIndex = genders.firstIndex(of: viewModel.filterOptions.gender) {
             charactersFilterView.genderSegmentControl.selectedSegmentIndex = currentGenderIndex
         }
+
+        currentFilterOptions
+            .receive(on: DispatchQueue.main)
+            .map({ $0 })
+            .assign(to: \.filterOptions, on: self.viewModel)
+            .store(in: &cancellables)
     }
 
     @objc private func statusValueChanged() {
         let statusIndex = charactersFilterView.statusSegmentControl.selectedSegmentIndex
         if statusIndex >= 0 {
-            viewModel.currentStatus = self.statuses[statusIndex]
-            viewModel.currentPage = 1
+            currentFilterOptions.value.status = self.statuses[statusIndex]
         }
     }
 
     @objc private func genderValueChanged() {
         let genderIndex = charactersFilterView.genderSegmentControl.selectedSegmentIndex
         if genderIndex >= 0 {
-            viewModel.currentGender = self.genders[genderIndex]
-            viewModel.currentPage = 1
+            currentFilterOptions.value.gender = self.genders[genderIndex]
         }
     }
 
@@ -75,8 +84,6 @@ class CharactersFilterViewController: UIViewController {
     @objc private func clearButtonTapped() {
         charactersFilterView.statusSegmentControl.selectedSegmentIndex = -1
         charactersFilterView.genderSegmentControl.selectedSegmentIndex = -1
-        viewModel.currentStatus = ""
-        viewModel.currentGender = ""
-        viewModel.currentPage = 1
+        currentFilterOptions.value = FilterOptions(status: "", gender: "")
     }
 }

--- a/RickAndMorty-iOS/Views/Characters/CharactersFilterViewController.swift
+++ b/RickAndMorty-iOS/Views/Characters/CharactersFilterViewController.swift
@@ -39,8 +39,6 @@ class CharactersFilterViewController: UIViewController {
         super.viewDidLoad()
         charactersFilterView.statusSegmentControl.addTarget(self, action: #selector(statusValueChanged), for: .valueChanged)
         charactersFilterView.genderSegmentControl.addTarget(self, action: #selector(genderValueChanged), for: .valueChanged)
-
-        charactersFilterView.applyButton.addTarget(self, action: #selector(applyButtonTapped), for: .touchUpInside)
         charactersFilterView.dismissButton.addTarget(self, action: #selector(dismissButtonTapped), for: .touchUpInside)
         charactersFilterView.clearButton.addTarget(self, action: #selector(clearButtonTapped), for: .touchUpInside)
 
@@ -71,10 +69,6 @@ class CharactersFilterViewController: UIViewController {
         if genderIndex >= 0 {
             currentFilterOptions.value.gender = self.genders[genderIndex]
         }
-    }
-
-    @objc private func applyButtonTapped() {
-        self.dismiss(animated: true)
     }
 
     @objc private func dismissButtonTapped() {

--- a/RickAndMorty-iOS/Views/Characters/CharactersView.swift
+++ b/RickAndMorty-iOS/Views/Characters/CharactersView.swift
@@ -81,7 +81,7 @@ class CharactersView: UIView {
 
     private func setupConstraints() {
         collectionView.snp.makeConstraints { make in
-            make.edges.equalTo(self.safeAreaInsets).inset(UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 10))
+            make.edges.equalTo(safeAreaInsets).inset(UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 10))
         }
     }
 }

--- a/RickAndMorty-iOS/Views/Characters/CharactersViewController.swift
+++ b/RickAndMorty-iOS/Views/Characters/CharactersViewController.swift
@@ -109,9 +109,9 @@ extension CharactersViewController: UICollectionViewDelegate {
         if indexPath.row == collectionView.numberOfItems(inSection: indexPath.section) - 1 {
             // show lazy-loading indicator
             charactersGridView.loadingIndicator.startAnimating()
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-                self.loadMore()
-                self.charactersGridView.loadingIndicator.stopAnimating()
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak self] in
+                self?.loadMore()
+                self?.charactersGridView.loadingIndicator.stopAnimating()
             }
         }
     }

--- a/RickAndMorty-iOS/Views/Characters/CharactersViewController.swift
+++ b/RickAndMorty-iOS/Views/Characters/CharactersViewController.swift
@@ -23,7 +23,6 @@ class CharactersViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
         configureDataSource()
         showEmptyData()
         subscribeToViewModel()
@@ -50,16 +49,18 @@ class CharactersViewController: UIViewController {
     }
 
     func subscribeToViewModel() {
-        viewModel.characters.sink(receiveValue: { [self] characters in
+        viewModel.characters.sink(receiveValue: { [weak self] characters in
             if !characters.isEmpty {
-                snapshot.deleteAllItems()
-                snapshot.appendSections([.appearance])
-                snapshot.appendItems(characters, toSection: .appearance)
-                self.dataSource.apply(snapshot, animatingDifferences: true)
+                if var snapshot = self?.snapshot {
+                    snapshot.deleteAllItems()
+                    snapshot.appendSections([.appearance])
+                    snapshot.appendItems(characters, toSection: .appearance)
+                    self?.dataSource.apply(snapshot, animatingDifferences: true)
+                }
             }
             // Dismiss refresh control.
             DispatchQueue.main.async {
-                self.charactersGridView.collectionView.refreshControl?.endRefreshing()
+                self?.charactersGridView.collectionView.refreshControl?.endRefreshing()
             }
         }).store(in: &cancellables)
     }
@@ -92,7 +93,7 @@ extension CharactersViewController {
             if let char = character as? RickAndMortyAPI.CharacterBasics {
                 characterCell!.characterNameLabel.text = char.name
                 if let image = char.image {
-                    characterCell!.characterImage.sd_setImage(with: URL(string: image))
+                    characterCell!.characterImage.sd_setImage(with: URL(string: image), placeholderImage: nil, context: [.imageThumbnailPixelSize: CGSize(width: 200, height: 200)])
                 }
             }
             hideLoadingAnimation(currentCell: characterCell!)
@@ -116,6 +117,6 @@ extension CharactersViewController: UICollectionViewDelegate {
     }
 
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        coordinator?.goCharacterDetails(id: viewModel.characters.value[indexPath.row].id!, navController: self.navigationController!)
+         coordinator?.goCharacterDetails(id: viewModel.characters.value[indexPath.row].id!, navController: self.navigationController!)
     }
 }

--- a/RickAndMorty-iOS/Views/Characters/CharactersViewController.swift
+++ b/RickAndMorty-iOS/Views/Characters/CharactersViewController.swift
@@ -64,13 +64,7 @@ class CharactersViewController: UIViewController {
         }).store(in: &cancellables)
     }
 
-    func subscribeToFilter() {
-
-    }
-
     @objc func onRefresh() {
-        viewModel.currentGender = ""
-        viewModel.currentStatus = ""
         viewModel.currentPage = 1
     }
 

--- a/RickAndMorty-iOS/Views/Episodes/EpisodeDetailsView.swift
+++ b/RickAndMorty-iOS/Views/Episodes/EpisodeDetailsView.swift
@@ -46,7 +46,7 @@ class EpisodeDetailsView: UIView {
 
     private func setupConstraints() {
         collectionView.snp.makeConstraints { make in
-            make.edges.equalTo(self.safeAreaLayoutGuide).inset(UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 10))
+            make.edges.equalTo(safeAreaLayoutGuide).inset(UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 10))
         }
     }
 }
@@ -54,7 +54,7 @@ class EpisodeDetailsView: UIView {
 // MARK: - CollectionView Layout
 extension EpisodeDetailsView {
     private func createLayout() -> UICollectionViewLayout {
-        let layout = UICollectionViewCompositionalLayout { (sectionIndex, _) -> NSCollectionLayoutSection? in
+        let layout = UICollectionViewCompositionalLayout { [weak self] (sectionIndex, _) -> NSCollectionLayoutSection? in
 
             guard let sectionType = Section(rawValue: sectionIndex) else {
                 return nil
@@ -79,7 +79,7 @@ extension EpisodeDetailsView {
             let headerSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .estimated(50))
             let header = NSCollectionLayoutBoundarySupplementaryItem(layoutSize: headerSize, elementKind: UICollectionView.elementKindSectionHeader, alignment: .top)
 
-            if self.collectionView.numberOfItems(inSection: sectionIndex) > 0 {
+            if (self?.collectionView.numberOfItems(inSection: sectionIndex) ?? 0) > 0 {
                 section.boundarySupplementaryItems = [header]
             }
 

--- a/RickAndMorty-iOS/Views/Episodes/EpisodesView.swift
+++ b/RickAndMorty-iOS/Views/Episodes/EpisodesView.swift
@@ -51,7 +51,7 @@ class EpisodesView: UIView {
 
     private func setupConstraints() {
         collectionView.snp.makeConstraints { make in
-            make.edges.equalTo(self.safeAreaLayoutGuide).inset(UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 10))
+            make.edges.equalTo(safeAreaLayoutGuide).inset(UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 10))
         }
     }
 }

--- a/RickAndMorty-iOS/Views/Locations/LocationDetailsView.swift
+++ b/RickAndMorty-iOS/Views/Locations/LocationDetailsView.swift
@@ -46,7 +46,7 @@ class LocationDetailsView: UIView {
 
     private func setupConstraints() {
         collectionView.snp.makeConstraints { make in
-            make.edges.equalTo(self.safeAreaLayoutGuide).inset(UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 10))
+            make.edges.equalTo(safeAreaLayoutGuide).inset(UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 10))
         }
     }
 }
@@ -54,7 +54,7 @@ class LocationDetailsView: UIView {
 // MARK: - CollectionView Layout
 extension LocationDetailsView {
     private func createLayout() -> UICollectionViewLayout {
-        let layout = UICollectionViewCompositionalLayout { (sectionIndex, _) -> NSCollectionLayoutSection? in
+        let layout = UICollectionViewCompositionalLayout { [weak self] (sectionIndex, _) -> NSCollectionLayoutSection? in
 
             guard let sectionType = Section(rawValue: sectionIndex) else {
                 return nil
@@ -79,7 +79,7 @@ extension LocationDetailsView {
             let headerSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .estimated(50))
             let header = NSCollectionLayoutBoundarySupplementaryItem(layoutSize: headerSize, elementKind: UICollectionView.elementKindSectionHeader, alignment: .top)
 
-            if self.collectionView.numberOfItems(inSection: sectionIndex) > 0 {
+            if (self?.collectionView.numberOfItems(inSection: sectionIndex)) ?? 0 > 0 {
                 section.boundarySupplementaryItems = [header]
             }
             return section

--- a/RickAndMorty-iOS/Views/Locations/LocationDetailsViewController.swift
+++ b/RickAndMorty-iOS/Views/Locations/LocationDetailsViewController.swift
@@ -63,18 +63,20 @@ class LocationDetailsViewController: UIViewController {
     }
 
     func subscribeToViewModel() {
-        viewModel.location.sink(receiveValue: { [self] location in
-            self.title = location.name
+        viewModel.location.sink(receiveValue: { [weak self] location in
+            self?.title = location.name
             if !location.residents.isEmpty {
-                snapshot.deleteAllItems()
-                snapshot.appendSections([.info, .residents])
-                snapshot.appendItems([LocationDetails(location), LocationDetails(location)], toSection: .info)
-                snapshot.appendItems(location.residents, toSection: .residents)
-                self.dataSource.apply(snapshot, animatingDifferences: true)
+                if var snapshot = self?.snapshot {
+                    snapshot.deleteAllItems()
+                    snapshot.appendSections([.info, .residents])
+                    snapshot.appendItems([LocationDetails(location), LocationDetails(location)], toSection: .info)
+                    snapshot.appendItems(location.residents, toSection: .residents)
+                    self?.dataSource.apply(snapshot, animatingDifferences: true)
+                }
             }
             // Dismiss refresh control.
             DispatchQueue.main.async {
-                self.locationDetailsView.collectionView.refreshControl?.endRefreshing()
+                self?.locationDetailsView.collectionView.refreshControl?.endRefreshing()
             }
 
         }).store(in: &cancellables)
@@ -88,7 +90,7 @@ class LocationDetailsViewController: UIViewController {
 // MARK: - CollectionView DataSource
 extension LocationDetailsViewController {
     private func configureDataSource() {
-        dataSource = DataSource(collectionView: locationDetailsView.collectionView, cellProvider: { (collectionView, indexPath, location) -> UICollectionViewCell? in
+        dataSource = DataSource(collectionView: locationDetailsView.collectionView, cellProvider: { [weak self] (collectionView, indexPath, location) -> UICollectionViewCell? in
 
             let infoCell = collectionView.dequeueReusableCell(withReuseIdentifier: InfoCell.identifier, for: indexPath) as? InfoCell
             let characterRowCell = collectionView.dequeueReusableCell(withReuseIdentifier: CharacterRowCell.identifier, for: indexPath) as? CharacterRowCell
@@ -96,11 +98,11 @@ extension LocationDetailsViewController {
             switch indexPath.section {
             case 0:
                 hideLoadingAnimation(currentCell: infoCell!)
-                return self.configLocationInfoCell(cell: infoCell!, data: location, itemIndex: indexPath.item)
+                return self?.configLocationInfoCell(cell: infoCell!, data: location, itemIndex: indexPath.item)
             case 1:
                 if let character = location as? RickAndMortyAPI.GetLocationQuery.Data.Location.Resident? {
                     let urlString = character?.image ?? ""
-                    characterRowCell?.characterAvatarImageView.sd_setImage(with: URL(string: urlString))
+                    characterRowCell?.characterAvatarImageView.sd_setImage(with: URL(string: urlString), placeholderImage: nil, context: [.imageThumbnailPixelSize: CGSize(width: 100, height: 100)])
                     characterRowCell?.upperLabel.text = character?.name
                     characterRowCell?.lowerLeftLabel.text = character?.gender
                     characterRowCell?.lowerRightLabel.text = character?.species
@@ -122,8 +124,8 @@ extension LocationDetailsViewController {
         })
 
         // for custom header
-        dataSource.supplementaryViewProvider = { (_ collectionView, _ kind, indexPath) in
-            guard let headerView = self.locationDetailsView.collectionView.dequeueReusableSupplementaryView(ofKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: "HeaderView", for: indexPath) as? HeaderView else {
+        dataSource.supplementaryViewProvider = { [weak self] (_ collectionView, _ kind, indexPath) in
+            guard let headerView = self?.locationDetailsView.collectionView.dequeueReusableSupplementaryView(ofKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: "HeaderView", for: indexPath) as? HeaderView else {
                 fatalError()
             }
             headerView.textLabel.text = indexPath.section == 0 || indexPath.section == 2 ? "INFO" : "RESIDENTS"

--- a/RickAndMorty-iOS/Views/Locations/LocationsView.swift
+++ b/RickAndMorty-iOS/Views/Locations/LocationsView.swift
@@ -10,8 +10,8 @@ import SnapKit
 
 class LocationsView: UIView {
 
-    lazy var collectionView: UICollectionView = {
-        let collectionView = UICollectionView(frame: self.bounds, collectionViewLayout: createLayout())
+    lazy var collectionView: UICollectionView = { [weak self] in
+        let collectionView = UICollectionView(frame: self?.bounds ?? CGRect.zero, collectionViewLayout: createLayout())
         collectionView.register(LocationRowCell.self,
                                 forCellWithReuseIdentifier: LocationRowCell.identifier)
 
@@ -41,7 +41,7 @@ class LocationsView: UIView {
 
     private func setupConstraints() {
         collectionView.snp.makeConstraints { make in
-            make.edges.equalTo(self.safeAreaLayoutGuide).inset(UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 10))
+            make.edges.equalTo(safeAreaLayoutGuide).inset(UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 10))
         }
     }
 

--- a/RickAndMorty-iOS/Views/Locations/LocationsViewController.swift
+++ b/RickAndMorty-iOS/Views/Locations/LocationsViewController.swift
@@ -46,16 +46,18 @@ class LocationsViewController: UIViewController {
     }
 
     func subscribeToViewModel() {
-        viewModel.locations.sink(receiveValue: { [self] locations in
+        viewModel.locations.sink(receiveValue: { [weak self] locations in
             if !locations.isEmpty {
-                snapshot.deleteAllItems()
-                snapshot.appendSections([.appearance])
-                snapshot.appendItems(locations, toSection: .appearance)
-                self.dataSource.apply(snapshot, animatingDifferences: true)
+                if var snapshot = self?.snapshot {
+                    snapshot.deleteAllItems()
+                    snapshot.appendSections([.appearance])
+                    snapshot.appendItems(locations, toSection: .appearance)
+                    self?.dataSource.apply(snapshot, animatingDifferences: true)
+                }
             }
             // Dismiss refresh control.
             DispatchQueue.main.async {
-                self.locationsView.collectionView.refreshControl?.endRefreshing()
+                self?.locationsView.collectionView.refreshControl?.endRefreshing()
             }
 
         }).store(in: &cancellables)
@@ -90,7 +92,7 @@ extension LocationsViewController {
                 let isIndexValid = location?.residents.indices.contains(index)
                 if isIndexValid! {
                     let urlString = location?.residents[index]?.image ?? ""
-                    cell?.characterAvatarImageViews[index].sd_setImage(with: URL(string: urlString))
+                    cell?.characterAvatarImageViews[index].sd_setImage(with: URL(string: urlString), placeholderImage: nil, context: [.imageThumbnailPixelSize: CGSize(width: 50, height: 50)])
                 }
             }
             hideLoadingAnimation(currentCell: cell!)

--- a/RickAndMorty-iOS/Views/Search/SearchView.swift
+++ b/RickAndMorty-iOS/Views/Search/SearchView.swift
@@ -29,7 +29,7 @@ class SearchView: UIView {
             let isIndexValid = location.residents.indices.contains(index)
             if isIndexValid {
                 let urlString = location.residents[index]?.image ?? ""
-                cell.characterAvatarImageViews[index].sd_setImage(with: URL(string: urlString))
+                cell.characterAvatarImageViews[index].sd_setImage(with: URL(string: urlString), placeholderImage: nil, context: [.imageThumbnailPixelSize: CGSize(width: 100, height: 100)])
             }
         }
     }
@@ -56,12 +56,12 @@ class SearchView: UIView {
 
     private func setupConstraints() {
         collectionView.snp.makeConstraints { make in
-            make.edges.equalTo(self.safeAreaLayoutGuide).inset(UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 10))
+            make.edges.equalTo(safeAreaLayoutGuide).inset(UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 10))
         }
     }
 
     private func createLayout() -> UICollectionViewLayout {
-        let layout = UICollectionViewCompositionalLayout { (sectionIndex, _) -> NSCollectionLayoutSection? in
+        let layout = UICollectionViewCompositionalLayout { [weak self] (sectionIndex, _) -> NSCollectionLayoutSection? in
 
             guard let sectionType = Section(rawValue: sectionIndex) else {
                 return nil
@@ -84,7 +84,7 @@ class SearchView: UIView {
             let headerSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .estimated(50))
             let header = NSCollectionLayoutBoundarySupplementaryItem(layoutSize: headerSize, elementKind: UICollectionView.elementKindSectionHeader, alignment: .top)
 
-            if self.collectionView.numberOfItems(inSection: sectionIndex) > 0 {
+            if (self?.collectionView.numberOfItems(inSection: sectionIndex) ?? 0) > 0 {
                 section.boundarySupplementaryItems = [header]
             }
             return section

--- a/RickAndMorty-iOS/Views/Search/SearchViewController.swift
+++ b/RickAndMorty-iOS/Views/Search/SearchViewController.swift
@@ -190,10 +190,12 @@ extension SearchViewController: UICollectionViewDelegate {
         charactersSearchViewModel.name = viewModel.searchInput
         charactersSearchViewModel.currentPage = currentCharactersPage
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [self] in
-            let newCharacters = charactersSearchViewModel.charactersForSearch.value
-            snapshot.appendItems(newCharacters, toSection: .characters)
-            dataSource.apply(snapshot, animatingDifferences: true)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak self] in
+            let newCharacters = self?.charactersSearchViewModel.charactersForSearch.value
+            self?.snapshot.appendItems(newCharacters ?? [], toSection: .characters)
+            if let snapshot = self?.snapshot {
+                self?.dataSource.apply(snapshot, animatingDifferences: true)
+            }
         }
     }
 
@@ -209,13 +211,15 @@ extension SearchViewController: UICollectionViewDelegate {
         locationTypeViewModel.type = viewModel.searchInput
         locationTypeViewModel.currentPage = currentLocationsPage
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [self] in
-            uniqueLocations += (locationNameViewModel.locationsNameSearch.value + locationTypeViewModel.locationsTypeSearch.value)
-            let newUniqueLocations = Array(Set(uniqueLocations))
-            let locationsIDs = snapshot.itemIdentifiers(inSection: .locations)
-            snapshot.deleteItems(locationsIDs)
-            snapshot.appendItems(newUniqueLocations, toSection: .locations)
-            dataSource.apply(snapshot, animatingDifferences: false)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak self] in
+            self?.uniqueLocations += ((self?.locationNameViewModel.locationsNameSearch.value ?? []) + (self?.locationTypeViewModel.locationsTypeSearch.value ?? []))
+            let newUniqueLocations = Array(Set((self?.uniqueLocations) ?? []))
+            let locationsIDs = self?.snapshot.itemIdentifiers(inSection: .locations)
+            self?.snapshot.deleteItems(locationsIDs ?? [])
+            self?.snapshot.appendItems(newUniqueLocations, toSection: .locations)
+            if let snapshot = self?.snapshot {
+                self?.dataSource.apply(snapshot, animatingDifferences: false)
+            }
         }
     }
 }

--- a/RickAndMorty-iOS/Views/Shared/CharacterGridCell.swift
+++ b/RickAndMorty-iOS/Views/Shared/CharacterGridCell.swift
@@ -20,10 +20,10 @@ class CharacterGridCell: UICollectionViewCell {
         return label
     }()
 
-    lazy var characterImage: UIImageView = {
+    lazy var characterImage: UIImageView = { [weak self] in
         let imageView = UIImageView()
         imageView.layer.masksToBounds = true
-        imageView.layer.cornerRadius = self.layer.cornerRadius
+        imageView.layer.cornerRadius = self?.layer.cornerRadius ?? 0
         imageView.contentMode = .scaleAspectFill
         return imageView
     }()
@@ -43,7 +43,7 @@ class CharacterGridCell: UICollectionViewCell {
 
     func setupConstraints() {
         characterImage.snp.makeConstraints { make in
-            make.edges.equalTo(self)
+            make.edges.equalToSuperview()
         }
 
         characterNameLabel.snp.makeConstraints { make in

--- a/RickAndMorty-iOS/Views/Shared/CharacterRowCell.swift
+++ b/RickAndMorty-iOS/Views/Shared/CharacterRowCell.swift
@@ -122,7 +122,7 @@ class CharacterRowCell: UICollectionViewListCell {
             make.left.equalToSuperview().offset(10)
             make.centerY.equalToSuperview()
             make.height.equalToSuperview().offset(-20)
-            make.width.equalTo(self.snp.height).offset(-20).multipliedBy(1.0 / 1.0)
+            make.width.equalTo(snp.height).offset(-20).multipliedBy(1.0 / 1.0)
         }
 
         upperLabel.snp.makeConstraints { make in

--- a/RickAndMorty-iOS/Views/Shared/InfoCell.swift
+++ b/RickAndMorty-iOS/Views/Shared/InfoCell.swift
@@ -62,22 +62,22 @@ class InfoCell: UICollectionViewListCell {
 
     func setupConstraints() {
         leftLabel.snp.makeConstraints { make in
-            make.left.equalTo(self).offset(60)
+            make.left.equalToSuperview().offset(60)
             make.top.equalToSuperview()
             make.bottom.equalToSuperview()
             make.width.equalToSuperview().offset(-20).multipliedBy(0.5)
         }
         rightLabel.snp.makeConstraints { make in
-            make.right.equalTo(self).offset(-25)
+            make.right.equalToSuperview().offset(-25)
             make.top.equalToSuperview()
             make.bottom.equalToSuperview()
             make.width.equalToSuperview().offset(-20).multipliedBy(0.5)
         }
         infoImage.snp.makeConstraints { make in
-            make.left.equalTo(self).offset(25)
+            make.left.equalToSuperview().offset(25)
             make.width.equalTo(25)
             make.height.equalTo(25)
-            make.top.equalTo(self).offset(12)
+            make.top.equalToSuperview().offset(12)
         }
     }
 

--- a/RickAndMorty-iOS/Views/Shared/RowCell.swift
+++ b/RickAndMorty-iOS/Views/Shared/RowCell.swift
@@ -91,7 +91,7 @@ class RowCell: UICollectionViewListCell {
         characterAvatarsView.snp.makeConstraints { make in
             make.top.left.equalToSuperview().offset(2)
             make.height.equalToSuperview().offset(-8)
-            make.width.equalTo(self.snp.height).multipliedBy(1.0 / 1.0)
+            make.width.equalTo(snp.height).multipliedBy(1.0 / 1.0)
         }
 
         characterAvatarImageViews[0].snp.makeConstraints { make in


### PR DESCRIPTION
- Change all references of `self` to `[weak self]` in closures.
- Add `context` parameter to `sd_setImage()` calls to specify thumbnail size to prevent unnecessary memory usage.
- This PR also includes enhancements to the Characters Filter View with Combine.